### PR TITLE
[CORRECTION] Corrige le coché/décoché de la checkbox Matomo

### DIFF
--- a/app/public/assets/scripts/optout-matomo.js
+++ b/app/public/assets/scripts/optout-matomo.js
@@ -1,18 +1,18 @@
-$(document).ready(() => {
-  const modifieLabelConsentement = () => {
-    const optOutMatomo = localStorage.getItem("optOutMatomo") === "true";
-    $("#label-consentement-matomo").text(
-      optOutMatomo
-        ? "Vous n'êtes actuellement pas suivi(e). Cochez cette case pour ne plus être exclu(e)."
-        : "Vous êtes suivi(e) de manière anonyme. Décochez cette case pour vous exclure du suivi.",
-    );
-  };
+const modifieCheckboxConsentement = (estOptOut) => {
+  $("#consentement-matomo").prop("checked", !estOptOut);
+  $("#label-consentement-matomo").text(
+    estOptOut
+      ? "Vous n'êtes actuellement pas suivi(e). Cochez cette case pour ne plus être exclu(e)."
+      : "Vous êtes suivi(e) de manière anonyme. Décochez cette case pour vous exclure du suivi.",
+  );
+};
 
+$(document).ready(() => {
   $("#consentement-matomo").on("change", () => {
     const optOutMatomo = !$("#consentement-matomo").is(":checked");
-    localStorage.setItem("optOutMatomo", optOutMatomo);
-    modifieLabelConsentement();
+    localStorage.setItem("optOutMatomo", String(optOutMatomo));
+    modifieCheckboxConsentement(optOutMatomo);
   });
 
-  modifieLabelConsentement();
+  modifieCheckboxConsentement(localStorage.getItem("optOutMatomo") === "true");
 });

--- a/app/vues/politique-confidentialite.pug
+++ b/app/vues/politique-confidentialite.pug
@@ -35,7 +35,7 @@ block body
         ]
     )
     .conteneur-checkbox
-      input(type="checkbox" id="consentement-matomo" name="consentement-matomo" checked)
+      input(type="checkbox" id="consentement-matomo" name="consentement-matomo")
       label(for="consentement-matomo" id="label-consentement-matomo")
 
     +blocContenu(


### PR DESCRIPTION
Avec l'implémentation précédente, on avait un état incohérent au refresh de la page. La case était toujours cochée. Le texte, lui, était correct.