### PR TITLE
Initialise l’entrepôt utilisateur chiffré

### DIFF
--- a/back/.env.template
+++ b/back/.env.template
@@ -42,3 +42,10 @@ SECRET_JWT= # Secret utilisé pour le token JWT
 # des valeurs de n consécutives et commençant par 1
 HACHAGE_SECRET_DE_HACHAGE_1= # Secret à utiliser pour le hachage HMAC
 #HACHAGE_SECRET_DE_HACHAGE_2= # Second secret à utiliser pour le hachage HMAC
+
+#############################
+#                           #
+#     CHIFFREMENT           #
+#                           #
+#############################
+CHIFFREMENT_CHACHA20_CLE_HEX= # Clé à utiliser pour le chiffrement ChaCha20 en mémoire au format hexadecimal. Ex: f1e2d3c4b5a6978877665544332211ffeeddccbbaa9988776655443322110000

--- a/back/migrations/20250902063842_ajouteColonneDonneesAUtilisateurs.ts
+++ b/back/migrations/20250902063842_ajouteColonneDonneesAUtilisateurs.ts
@@ -1,0 +1,13 @@
+import type { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('utilisateurs', (table) => {
+    table.jsonb('donnees');
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('utilisateurs', (table) => {
+    table.dropColumn('donnees');
+  });
+}

--- a/back/src/infra/adaptateurChiffrement.ts
+++ b/back/src/infra/adaptateurChiffrement.ts
@@ -1,0 +1,79 @@
+import { createCipheriv, createDecipheriv, randomBytes } from 'crypto';
+import { AdaptateurEnvironnement } from './adaptateurEnvironnement';
+
+export type ObjetChiffre = {
+  iv: string;
+  aad: string;
+  donnees: string;
+  tag: string;
+};
+
+export const adaptateurChiffrement = ({
+  adaptateurEnvironnement,
+}: {
+  adaptateurEnvironnement: AdaptateurEnvironnement;
+}): AdaptateurChiffrement => {
+  const clefSecreteEnChaine = adaptateurEnvironnement
+    .chiffrement()
+    .cleChaCha20Hex();
+  const clefSecrete = Buffer.from(clefSecreteEnChaine, 'hex');
+
+  return {
+    chiffre: (chaine) => {
+      const iv = randomBytes(12);
+      const aad = randomBytes(16);
+      const donneesAChiffrer = JSON.stringify(chaine);
+
+      const chiffreur = createCipheriv('chacha20-poly1305', clefSecrete, iv, {
+        authTagLength: 16,
+      });
+      chiffreur.setAAD(aad, {
+        plaintextLength: Buffer.byteLength(donneesAChiffrer),
+      });
+
+      const donneesChiffrees = Buffer.concat([
+        chiffreur.update(donneesAChiffrer, 'utf-8'),
+        chiffreur.final(),
+      ]);
+      const tag = chiffreur.getAuthTag();
+
+      return {
+        iv: iv.toString('hex'),
+        aad: aad.toString('hex'),
+        donnees: donneesChiffrees.toString('hex'),
+        tag: tag.toString('hex'),
+      };
+    },
+    dechiffre: (donneesChiffrees) => {
+      const { iv, aad, donnees, tag } = donneesChiffrees;
+
+      const dechiffreur = createDecipheriv(
+        'chacha20-poly1305',
+        clefSecrete,
+        Buffer.from(iv, 'hex'),
+        { authTagLength: 16 }
+      );
+      dechiffreur.setAAD(Buffer.from(aad, 'hex'), {
+        plaintextLength: donnees.length,
+      });
+      dechiffreur.setAuthTag(Buffer.from(tag, 'hex'));
+
+      const chaineDechiffree = Buffer.concat([
+        dechiffreur.update(Buffer.from(donnees, 'hex')),
+        dechiffreur.final(),
+      ]);
+      return JSON.parse(chaineDechiffree.toString());
+    },
+  };
+};
+
+export interface AdaptateurChiffrement {
+  chiffre<T>(donnees: T): ObjetChiffre;
+  dechiffre<T>(objetChiffre: ObjetChiffre): T;
+}
+
+export const fabriqueAdaptateurChiffrement = ({
+  adaptateurEnvironnement,
+}: {
+  adaptateurEnvironnement: AdaptateurEnvironnement;
+}) => adaptateurChiffrement({ adaptateurEnvironnement });

--- a/back/src/infra/adaptateurEnvironnement.ts
+++ b/back/src/infra/adaptateurEnvironnement.ts
@@ -6,6 +6,9 @@ type OIDC = {
   clientSecret: () => string;
 };
 export type AdaptateurEnvironnement = {
+  chiffrement: () => {
+    cleChaCha20Hex: () => string;
+  };
   grist: () => {
     urlDeBase: string;
     cleApi: string;
@@ -69,6 +72,17 @@ export const adaptateurEnvironnement: AdaptateurEnvironnement = {
         .sort(
           ({ version: version1 }, { version: version2 }) => version1 - version2
         );
+    },
+  }),
+  chiffrement: () => ({
+    cleChaCha20Hex: () => {
+      const cleHex = process.env.CHIFFREMENT_CHACHA20_CLE_HEX;
+      if (!cleHex) {
+        throw new Error(
+          `La clé de chiffrement CHIFFREMENT_CHACHA20_CLE_HEX ne doit pas être vide`
+        );
+      }
+      return cleHex;
     },
   }),
 };

--- a/back/src/infra/entrepotUtilisateurPostgres.ts
+++ b/back/src/infra/entrepotUtilisateurPostgres.ts
@@ -31,7 +31,7 @@ export class EntrepotUtilisateurPostgres implements EntrepotUtilisateur {
     this.adaptateurChiffrement = adaptateurChiffrement;
   }
 
-  async ajoute(utilisateur: Utilisateur) {
+  async ajoute(utilisateur: Utilisateur): Promise<void> {
     await this.knex('utilisateurs').insert(
       this.utilisateurBDDAvecDonneesChiffrees(utilisateur)
     );
@@ -46,19 +46,19 @@ export class EntrepotUtilisateurPostgres implements EntrepotUtilisateur {
     return this.hydrateUtilisateur(utilisateur);
   }
 
-  async existe(emailHache: string) {
+  async existe(emailHache: string): Promise<boolean> {
     const utilisateur = await this.knex('utilisateurs')
       .where({ email_hache: emailHache })
       .first();
     return !!utilisateur;
   }
 
-  async tous() {
+  async tous(): Promise<Utilisateur[]> {
     const utilisateursBDD = await this.knex('utilisateurs');
     return utilisateursBDD.map(this.hydrateUtilisateur);
   }
 
-  async taille() {
+  async taille(): Promise<number> {
     const resultat = await this.knex('utilisateurs').count({ count: '*' });
     return Number(resultat[0].count);
   }

--- a/back/src/infra/entrepotUtilisateurPostgres.ts
+++ b/back/src/infra/entrepotUtilisateurPostgres.ts
@@ -1,16 +1,25 @@
 import Knex from 'knex';
+import config from '../../knexfile';
 import { EntrepotUtilisateur } from '../metier/entrepotUtilisateur';
 import { Utilisateur } from '../metier/utilisateur';
+import { AdaptateurChiffrement } from './adaptateurChiffrement';
 import { AdaptateurHachage } from './adaptateurHachage';
-import config from '../../knexfile';
 
 export class EntrepotUtilisateurPostgres implements EntrepotUtilisateur {
   knex: Knex.Knex;
   adaptateurHachage: AdaptateurHachage;
+  adaptateurChiffrement: AdaptateurChiffrement;
 
-  constructor({ adaptateurHachage }: { adaptateurHachage: AdaptateurHachage }) {
+  constructor({
+    adaptateurHachage,
+    adaptateurChiffrement,
+  }: {
+    adaptateurHachage: AdaptateurHachage;
+    adaptateurChiffrement: AdaptateurChiffrement;
+  }) {
     this.knex = Knex(config);
     this.adaptateurHachage = adaptateurHachage;
+    this.adaptateurChiffrement = adaptateurChiffrement;
   }
 
   async ajoute(_utilisateur: Utilisateur) {

--- a/back/src/infra/entrepotUtilisateurPostgres.ts
+++ b/back/src/infra/entrepotUtilisateurPostgres.ts
@@ -2,11 +2,16 @@ import Knex from 'knex';
 import config from '../../knexfile';
 import { EntrepotUtilisateur } from '../metier/entrepotUtilisateur';
 import { Utilisateur } from '../metier/utilisateur';
-import { AdaptateurChiffrement } from './adaptateurChiffrement';
+import { AdaptateurChiffrement, ObjetChiffre } from './adaptateurChiffrement';
 import { AdaptateurHachage } from './adaptateurHachage';
+
+type DonneesUtilisateurEnClair = {
+  email: string;
+};
 
 type UtilisateurBDD = {
   email_hache: string;
+  donnees: ObjetChiffre;
 };
 
 export class EntrepotUtilisateurPostgres implements EntrepotUtilisateur {
@@ -26,11 +31,12 @@ export class EntrepotUtilisateurPostgres implements EntrepotUtilisateur {
     this.adaptateurChiffrement = adaptateurChiffrement;
   }
 
-  async ajoute(_utilisateur: Utilisateur) {
-    {
-      throw new Error();
-    }
+  async ajoute(utilisateur: Utilisateur) {
+    await this.knex('utilisateurs').insert(
+      this.utilisateurBDDAvecDonneesChiffrees(utilisateur)
+    );
   }
+
   async parEmailHache(emailHache: string): Promise<Utilisateur | undefined> {
     if (!emailHache) return undefined;
     const utilisateur = await this.knex('utilisateurs')
@@ -54,14 +60,35 @@ export class EntrepotUtilisateurPostgres implements EntrepotUtilisateur {
     throw new Error();
   }
 
-  private hydrateUtilisateur(_utilisateur: UtilisateurBDD): Utilisateur {
+  private hydrateUtilisateur(utilisateur: UtilisateurBDD): Utilisateur {
+    const donnees = this.dechiffreDonneesUtilisateur(utilisateur);
     return new Utilisateur({
       cguAcceptees: true,
-      email: '',
+      email: donnees.email,
       infolettreAcceptee: true,
       nom: '',
       prenom: '',
       siretEntite: '',
     });
+  }
+
+  private utilisateurBDDAvecDonneesChiffrees(
+    utilisateur: Utilisateur
+  ): UtilisateurBDD {
+    const donneesEnClair: DonneesUtilisateurEnClair = {
+      email: utilisateur.email,
+    };
+    const donneesChiffrees = this.adaptateurChiffrement.chiffre(donneesEnClair);
+    return {
+      donnees: donneesChiffrees,
+      email_hache: this.adaptateurHachage.hache(utilisateur.email),
+    };
+  }
+
+  private dechiffreDonneesUtilisateur(
+    utilisateur: UtilisateurBDD
+  ): DonneesUtilisateurEnClair {
+    const { donnees } = utilisateur;
+    return this.adaptateurChiffrement.dechiffre(donnees);
   }
 }

--- a/back/src/infra/entrepotUtilisateurPostgres.ts
+++ b/back/src/infra/entrepotUtilisateurPostgres.ts
@@ -5,6 +5,10 @@ import { Utilisateur } from '../metier/utilisateur';
 import { AdaptateurChiffrement } from './adaptateurChiffrement';
 import { AdaptateurHachage } from './adaptateurHachage';
 
+type UtilisateurBDD = {
+  email_hache: string;
+};
+
 export class EntrepotUtilisateurPostgres implements EntrepotUtilisateur {
   knex: Knex.Knex;
   adaptateurHachage: AdaptateurHachage;
@@ -27,8 +31,13 @@ export class EntrepotUtilisateurPostgres implements EntrepotUtilisateur {
       throw new Error();
     }
   }
-  async parEmailHache(_emailHache: string): Promise<Utilisateur | undefined> {
-    throw new Error();
+  async parEmailHache(emailHache: string): Promise<Utilisateur | undefined> {
+    if (!emailHache) return undefined;
+    const utilisateur = await this.knex('utilisateurs')
+      .where({ email_hache: emailHache })
+      .first();
+    if (!utilisateur) return undefined;
+    return this.hydrateUtilisateur(utilisateur);
   }
 
   async existe(emailHache: string) {
@@ -43,5 +52,16 @@ export class EntrepotUtilisateurPostgres implements EntrepotUtilisateur {
   }
   async taille(): Promise<number> {
     throw new Error();
+  }
+
+  private hydrateUtilisateur(_utilisateur: UtilisateurBDD): Utilisateur {
+    return new Utilisateur({
+      cguAcceptees: true,
+      email: '',
+      infolettreAcceptee: true,
+      nom: '',
+      prenom: '',
+      siretEntite: '',
+    });
   }
 }

--- a/back/src/infra/entrepotUtilisateurPostgres.ts
+++ b/back/src/infra/entrepotUtilisateurPostgres.ts
@@ -1,7 +1,18 @@
+import Knex from 'knex';
 import { EntrepotUtilisateur } from '../metier/entrepotUtilisateur';
 import { Utilisateur } from '../metier/utilisateur';
+import { AdaptateurHachage } from './adaptateurHachage';
+import config from '../../knexfile';
 
 export class EntrepotUtilisateurPostgres implements EntrepotUtilisateur {
+  knex: Knex.Knex;
+  adaptateurHachage: AdaptateurHachage;
+
+  constructor({ adaptateurHachage }: { adaptateurHachage: AdaptateurHachage }) {
+    this.knex = Knex(config);
+    this.adaptateurHachage = adaptateurHachage;
+  }
+
   async ajoute(_utilisateur: Utilisateur) {
     {
       throw new Error();
@@ -10,9 +21,14 @@ export class EntrepotUtilisateurPostgres implements EntrepotUtilisateur {
   async parEmailHache(_emailHache: string): Promise<Utilisateur | undefined> {
     throw new Error();
   }
-  async existe(_emailHache: string): Promise<boolean> {
-    throw new Error();
+
+  async existe(emailHache: string) {
+    const utilisateur = await this.knex('utilisateurs')
+      .where({ email_hache: emailHache })
+      .first();
+    return !!utilisateur;
   }
+
   async tous(): Promise<Utilisateur[]> {
     throw new Error();
   }

--- a/back/src/infra/entrepotUtilisateurPostgres.ts
+++ b/back/src/infra/entrepotUtilisateurPostgres.ts
@@ -56,8 +56,10 @@ export class EntrepotUtilisateurPostgres implements EntrepotUtilisateur {
   async tous(): Promise<Utilisateur[]> {
     throw new Error();
   }
-  async taille(): Promise<number> {
-    throw new Error();
+
+  async taille() {
+    const resultat = await this.knex('utilisateurs').count({ count: '*' });
+    return Number(resultat[0].count);
   }
 
   private hydrateUtilisateur(utilisateur: UtilisateurBDD): Utilisateur {

--- a/back/src/infra/entrepotUtilisateurPostgres.ts
+++ b/back/src/infra/entrepotUtilisateurPostgres.ts
@@ -53,8 +53,9 @@ export class EntrepotUtilisateurPostgres implements EntrepotUtilisateur {
     return !!utilisateur;
   }
 
-  async tous(): Promise<Utilisateur[]> {
-    throw new Error();
+  async tous() {
+    const utilisateursBDD = await this.knex('utilisateurs');
+    return utilisateursBDD.map(this.hydrateUtilisateur);
   }
 
   async taille() {

--- a/back/src/infra/entrepotUtilisateurPostgres.ts
+++ b/back/src/infra/entrepotUtilisateurPostgres.ts
@@ -7,6 +7,10 @@ import { AdaptateurHachage } from './adaptateurHachage';
 
 type DonneesUtilisateurEnClair = {
   email: string;
+  prenom: string;
+  nom: string;
+  siret: string;
+  infolettreAcceptee: boolean;
 };
 
 type UtilisateurBDD = {
@@ -68,10 +72,10 @@ export class EntrepotUtilisateurPostgres implements EntrepotUtilisateur {
     return new Utilisateur({
       cguAcceptees: true,
       email: donnees.email,
-      infolettreAcceptee: true,
-      nom: '',
-      prenom: '',
-      siretEntite: '',
+      infolettreAcceptee: donnees.infolettreAcceptee,
+      nom: donnees.nom,
+      prenom: donnees.prenom,
+      siretEntite: donnees.siret,
     });
   }
 
@@ -80,6 +84,10 @@ export class EntrepotUtilisateurPostgres implements EntrepotUtilisateur {
   ): UtilisateurBDD {
     const donneesEnClair: DonneesUtilisateurEnClair = {
       email: utilisateur.email,
+      prenom: utilisateur.prenom,
+      nom: utilisateur.nom,
+      siret: utilisateur.siretEntite,
+      infolettreAcceptee: utilisateur.infolettreAcceptee,
     };
     const donneesChiffrees = this.adaptateurChiffrement.chiffre(donneesEnClair);
     return {

--- a/back/src/serveur.ts
+++ b/back/src/serveur.ts
@@ -8,6 +8,7 @@ import { EntrepotRessourcesCyberGrist } from './infra/entrepotRessourcesCyberGri
 import { EntrepotRessourcesCyberStatique } from './infra/entrepotRessourcesCyberStatique';
 import { EntrepotUtilisateurPostgres } from './infra/entrepotUtilisateurPostgres';
 import { recupereCheminVersFichiersStatiquesParDefaut } from './infra/recupereCheminVersFichiersStatiques';
+import { fabriqueAdaptateurChiffrement } from './infra/adaptateurChiffrement';
 
 const app = creeServeur({
   adaptateurOIDC,
@@ -19,6 +20,9 @@ const app = creeServeur({
   adaptateurHachage: fabriqueAdaptateurHachage({ adaptateurEnvironnement }),
   entrepotUtilisateur: new EntrepotUtilisateurPostgres({
     adaptateurHachage: fabriqueAdaptateurHachage({ adaptateurEnvironnement }),
+    adaptateurChiffrement: fabriqueAdaptateurChiffrement({
+      adaptateurEnvironnement,
+    }),
   }),
   recupereCheminVersFichiersStatiques:
     recupereCheminVersFichiersStatiquesParDefaut,

--- a/back/src/serveur.ts
+++ b/back/src/serveur.ts
@@ -17,7 +17,9 @@ const app = creeServeur({
     : new EntrepotRessourcesCyberGrist(),
   adaptateurJWT,
   adaptateurHachage: fabriqueAdaptateurHachage({ adaptateurEnvironnement }),
-  entrepotUtilisateur: new EntrepotUtilisateurPostgres(),
+  entrepotUtilisateur: new EntrepotUtilisateurPostgres({
+    adaptateurHachage: fabriqueAdaptateurHachage({ adaptateurEnvironnement }),
+  }),
   recupereCheminVersFichiersStatiques:
     recupereCheminVersFichiersStatiquesParDefaut,
 });

--- a/back/tests/api/fauxObjets.ts
+++ b/back/tests/api/fauxObjets.ts
@@ -55,6 +55,9 @@ export const fauxAdaptateurEnvironnement: AdaptateurEnvironnement = {
     ressourcesCyber: () => ({ idDocument: '', idTable: '' }),
   }),
   estEntrepotsStatiques: () => true,
+  chiffrement: () => ({
+    cleChaCha20Hex: () => 'uneCléCha20Hex',
+  }),
 };
 
 export type ConfigurationServeurDeTest = ConfigurationServeur & {


### PR DESCRIPTION
Implémente l’entrepôt des utilisateurs qui contient  :
- [x] le mail haché 
- [x] les données chiffrées suivantes :
  - [x] le mail
  - [x] le prénom
  - [x] le nom
  - [x] le siret
  - [x] l’indication de l’infolettre acceptée