### PR TITLE
Correction démarrage

### DIFF
--- a/back/package.json
+++ b/back/package.json
@@ -11,7 +11,7 @@
     "lint:fix": "npx eslint . --fix",
     "prestart": "tsc",
     "build": "tsc",
-    "start": "node ./dist/serveur.js",
+    "start": "node ./dist/src/serveur.js",
     "test": "vitest",
     "typecheck": "tsc --noEmit --project ./tsconfig.typecheck.json",
     "cree-migration": "knex migrate:make -x ts",

--- a/back/tsconfig.json
+++ b/back/tsconfig.json
@@ -3,5 +3,5 @@
   "compilerOptions": {
     "outDir": "./dist"
   },
-  "include": ["src"]
+  "include": ["src", "./knexfile.ts"]
 }

--- a/back/tsconfig.typecheck.json
+++ b/back/tsconfig.typecheck.json
@@ -1,4 +1,4 @@
 {
   "extends": "./tsconfig.json",
-  "include": ["src", "tests"]
+  "include": ["src", "tests", "migrations"]
 }


### PR DESCRIPTION
Suite à l'ajout de `knexfile.ts` à la racine, le répertoire `dist` contenait un sous-répertoire `src` qui n'était pas présent dans le ` package.json`