### PR TITLE
[CORRECTION] Modifie la méthode de récupération des fichiers front

### DIFF
--- a/back/src/infra/recupereCheminVersFichiersStatiques.ts
+++ b/back/src/infra/recupereCheminVersFichiersStatiques.ts
@@ -4,5 +4,5 @@ export type RecupereCheminVersFichiersStatiques = () => string;
 
 export const recupereCheminVersFichiersStatiquesParDefaut: RecupereCheminVersFichiersStatiques =
   () => {
-    return join(__dirname, '../../../front/dist');
+    return join(process.cwd(), '../front/dist');
   };


### PR DESCRIPTION
Le chemin vers le front dépendait de l'emplacement du fichier `recupereCheminVersFichiersStatiques.ts`, on a remplacé sa construction par un `process.cwd()` qui est moins aléatoire