### PR TITLE
Renforce les vérifications de type et lint au lancement des tests

### DIFF
--- a/back/package.json
+++ b/back/package.json
@@ -13,7 +13,7 @@
     "build": "tsc",
     "start": "node ./dist/src/serveur.js",
     "pretest": "npm-run-all --parallel typecheck lint",
-    "test": "vitest",
+    "test": "vitest run",
     "typecheck": "tsc --noEmit --project ./tsconfig.typecheck.json",
     "cree-migration": "knex migrate:make -x ts",
     "migre-bdd": "node --env-file=.env --import tsx ../node_modules/knex/bin/cli.js migrate:latest",

--- a/back/package.json
+++ b/back/package.json
@@ -12,6 +12,7 @@
     "prestart": "tsc",
     "build": "tsc",
     "start": "node ./dist/src/serveur.js",
+    "pretest": "npm-run-all --parallel typecheck lint",
     "test": "vitest",
     "typecheck": "tsc --noEmit --project ./tsconfig.typecheck.json",
     "cree-migration": "knex migrate:make -x ts",

--- a/front/package.json
+++ b/front/package.json
@@ -10,7 +10,7 @@
     "lint": "npx eslint .",
     "lint:fix": "npx eslint . --fix",
     "pretest": "npm-run-all --parallel lint",
-    "test": "vitest"
+    "test": "vitest run"
   },
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "^4.0.0",

--- a/front/package.json
+++ b/front/package.json
@@ -8,7 +8,9 @@
     "build": "vite build",
     "dev": "vite build --watch",
     "lint": "npx eslint .",
-    "lint:fix": "npx eslint . --fix"
+    "lint:fix": "npx eslint . --fix",
+    "pretest": "npm-run-all --parallel lint",
+    "test": "vitest"
   },
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "^4.0.0",


### PR DESCRIPTION
- Ajoute `pretest` côté back
- Ajoute `test` et `pretest` côté front
- Démarre `vitest` sans blocage en CLI (sans le mode "watch")