### PR TITLE
Vérifie les secrets de hachage au démarrage du serveur

### DIFF
--- a/back/.env.template
+++ b/back/.env.template
@@ -49,3 +49,10 @@ HACHAGE_SECRET_DE_HACHAGE_1= # Secret à utiliser pour le hachage HMAC
 #                           #
 #############################
 CHIFFREMENT_CHACHA20_CLE_HEX= # Clé à utiliser pour le chiffrement ChaCha20 en mémoire au format hexadecimal. Ex: f1e2d3c4b5a6978877665544332211ffeeddccbbaa9988776655443322110000
+
+#############################
+#                           #
+#     MAINTENANCE           #
+#                           #
+#############################
+MODE_MAINTENANCE= # 'true' pour activer le mode maintenance. Renvoi une erreur 503 et affiche une page dédiée pour toutes les requêtes

--- a/back/migrations/20250902092417_creationTableVersioningSecretHachage.ts
+++ b/back/migrations/20250902092417_creationTableVersioningSecretHachage.ts
@@ -1,0 +1,14 @@
+import type { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.createTable('secrets_hachage', (table) => {
+    table.integer('version');
+    table.primary(['version']);
+    table.text('empreinte');
+    table.datetime('date_migration').defaultTo(knex.fn.now());
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.dropTable('secrets_hachage');
+}

--- a/back/package.json
+++ b/back/package.json
@@ -47,6 +47,7 @@
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.4",
     "jiti": "^2.5.1",
+    "node-mocks-http": "^1.17.2",
     "supertest": "^7.1.4",
     "ts-node": "^10.9.2",
     "tsx": "^4.20.5",

--- a/back/src/admin/consoleAdministration.ts
+++ b/back/src/admin/consoleAdministration.ts
@@ -1,0 +1,36 @@
+/* eslint-disable no-console */
+import Knex from 'knex';
+import config from '../../knexfile';
+import { adaptateurEnvironnement } from '../infra/adaptateurEnvironnement';
+import { AdaptateurHachage, fabriqueAdaptateurHachage, } from '../infra/adaptateurHachage';
+
+export class ConsoleAdministration {
+  private readonly adaptateurHachage: AdaptateurHachage;
+  private knex: Knex.Knex;
+
+  constructor() {
+    this.adaptateurHachage = fabriqueAdaptateurHachage({
+      adaptateurEnvironnement,
+    });
+    this.knex = Knex(config);
+  }
+
+  async sauvegardeLesEmpreintesDesSecretsDeHachage() {
+    await this.knex.transaction(async (trx) => {
+      const tousLesSecretsDeHachage = adaptateurEnvironnement
+        .hachage()
+        .tousLesSecretsDeHachage();
+
+      const maj = tousLesSecretsDeHachage.map(async ({ version, secret }) => {
+        const empreinte = await this.adaptateurHachage.hacheBCrypt(secret);
+        return trx('secrets_hachage')
+          .insert({ version, empreinte })
+          .onConflict()
+          .ignore();
+      });
+
+      await Promise.all(maj);
+    });
+  }
+
+}

--- a/back/src/api/dsc.ts
+++ b/back/src/api/dsc.ts
@@ -14,6 +14,7 @@ import { ressourceConnexionOIDC } from './oidc/ressourceConnexionOIDC';
 import { ressourceDeconnexionOIDC } from './oidc/ressourceDeconnexionOIDC';
 import { ressourceProfil } from './ressourceProfil';
 import { ressourceRessourceCyber } from './ressourceRessourcesCyber';
+import { Middleware } from './middleware';
 
 export interface ConfigurationServeur {
   serveurLab: ConfigurationServeurLab;
@@ -23,6 +24,7 @@ export interface ConfigurationServeur {
   entrepotUtilisateur: EntrepotUtilisateur;
   adaptateurHachage: AdaptateurHachage;
   recupereCheminsVersFichiersStatiques: RecupereCheminVersFichiersStatiques;
+  middleware: Middleware;
 }
 
 export const creeServeur = (configurationServeur: ConfigurationServeur) => {
@@ -45,6 +47,8 @@ export const creeServeur = (configurationServeur: ConfigurationServeur) => {
     .forEach((chemin) => {
       app.use('/', express.static(chemin));
     });
+
+  app.use(configurationServeur.middleware.verifieModeMaintenance);
 
   app.use('/oidc/connexion', ressourceConnexionOIDC(configurationServeur));
   app.use(

--- a/back/src/api/middleware.ts
+++ b/back/src/api/middleware.ts
@@ -1,0 +1,38 @@
+import { NextFunction, Request, Response } from 'express';
+import { AdaptateurEnvironnement } from '../infra/adaptateurEnvironnement';
+import { HttpStatusCode } from 'axios';
+
+type FonctionMiddleware = (
+  requete: Request,
+  reponse: Response,
+  suite: NextFunction
+) => Promise<void>;
+
+export type Middleware = {
+  verifieModeMaintenance: FonctionMiddleware;
+};
+
+export const fabriqueMiddleware = ({
+  adaptateurEnvironnement,
+}: {
+  adaptateurEnvironnement: AdaptateurEnvironnement;
+}): Middleware => {
+  const verifieModeMaintenance = async (
+    _requete: Request,
+    reponse: Response,
+    suite: NextFunction
+  ) => {
+    if (adaptateurEnvironnement.maintenance().actif()) {
+      reponse
+        .status(HttpStatusCode.ServiceUnavailable)
+        .set('Content-Type', 'text/html')
+        .render('maintenance');
+    } else {
+      suite();
+    }
+  };
+
+  return {
+    verifieModeMaintenance,
+  };
+};

--- a/back/src/infra/adaptateurEnvironnement.ts
+++ b/back/src/infra/adaptateurEnvironnement.ts
@@ -22,9 +22,17 @@ export type AdaptateurEnvironnement = {
   hachage: () => {
     tousLesSecretsDeHachage: () => { version: number; secret: string }[];
   };
+  maintenance: () => {
+    actif: () => boolean;
+    detailsPreparation: () => string | undefined;
+  };
 };
 
 export const adaptateurEnvironnement: AdaptateurEnvironnement = {
+  maintenance: () => ({
+    actif: () => process.env.MODE_MAINTENANCE === 'true',
+    detailsPreparation: () => process.env.PREPARATION_MODE_MAINTENANCE,
+  }),
   oidc: (): OIDC => ({
     urlRedirectionApresAuthentification: () =>
       `${process.env.URL_BASE_DSC}/oidc/apres-authentification`,

--- a/back/src/infra/entrepotSecretHachagePostgres.ts
+++ b/back/src/infra/entrepotSecretHachagePostgres.ts
@@ -1,0 +1,21 @@
+import Knex from 'knex';
+import config from '../../knexfile';
+
+type SecretHachage = { version: number; empreinte: string };
+
+export interface EntrepotSecretHachage {
+  tous: () => Promise<SecretHachage[]>;
+}
+
+export class EntrepotSecretHachagePostgres implements EntrepotSecretHachage {
+  knex: Knex.Knex;
+
+  constructor() {
+    this.knex = Knex(config);
+  }
+
+  async tous(): Promise<SecretHachage[]> {
+    const empreintes = await this.knex('secrets_hachage');
+    return empreintes.map(({version, empreinte}) => ({version, empreinte}));
+  }
+}

--- a/back/src/infra/entrepotSecretHachagePostgres.ts
+++ b/back/src/infra/entrepotSecretHachagePostgres.ts
@@ -1,7 +1,7 @@
 import Knex from 'knex';
 import config from '../../knexfile';
 
-type SecretHachage = { version: number; empreinte: string };
+export type SecretHachage = { version: number; empreinte: string };
 
 export interface EntrepotSecretHachage {
   tous: () => Promise<SecretHachage[]>;

--- a/back/src/infra/serviceVerificationCoherenceSecretsHachage.ts
+++ b/back/src/infra/serviceVerificationCoherenceSecretsHachage.ts
@@ -1,0 +1,82 @@
+import {
+  EntrepotSecretHachage,
+  SecretHachage,
+} from './entrepotSecretHachagePostgres';
+import { AdaptateurHachage } from './adaptateurHachage';
+import { AdaptateurEnvironnement } from './adaptateurEnvironnement';
+
+const verifieQueChaqueSecretEstCoherent = async (
+  tousLesSecretsDeHachageDeLaConfig: { version: number; secret: string }[],
+  empreintesDesSecretsAppliques: SecretHachage[],
+  adaptateurHachage: AdaptateurHachage
+) => {
+  for (let i = 0; i < tousLesSecretsDeHachageDeLaConfig.length; i += 1) {
+    const { version: versionDeLaConfig, secret: valeurSecretEnClair } =
+      tousLesSecretsDeHachageDeLaConfig[i];
+    const leSecretAppliqueCorrespondant = empreintesDesSecretsAppliques.find(
+      ({ version: versionEnBase }) => versionEnBase === versionDeLaConfig
+    );
+
+    if (!leSecretAppliqueCorrespondant) {
+      throw new Error(
+        `💥 La version ${versionDeLaConfig} du secret noté dans la config est manquante dans la persistance.`
+      );
+    }
+    const estValide = await adaptateurHachage.compareBCrypt(
+      valeurSecretEnClair,
+      leSecretAppliqueCorrespondant.empreinte
+    );
+
+    if (!estValide) {
+      throw new Error(
+        `💥 La version ${versionDeLaConfig} du secret de la config a une valeur différente de celle déjà appliquée.`
+      );
+    }
+  }
+
+  for (const empreinte of empreintesDesSecretsAppliques) {
+    const { version: versionAppliquee } = empreinte;
+    if (
+      !tousLesSecretsDeHachageDeLaConfig.some(
+        ({ version: versionDansLaConfig }) =>
+          versionAppliquee === versionDansLaConfig
+      )
+    ) {
+      throw new Error(
+        `💥 La version ${versionAppliquee} du secret déjà appliquée est manquante dans la config.`
+      );
+    }
+  }
+};
+
+export const fabriqueServiceVerificationCoherenceSecretsHachage = ({
+  adaptateurHachage,
+  entrepotSecretHachage,
+  adaptateurEnvironnement,
+}: {
+  entrepotSecretHachage: EntrepotSecretHachage;
+  adaptateurHachage: AdaptateurHachage;
+  adaptateurEnvironnement: AdaptateurEnvironnement;
+}) => ({
+  verifieCoherenceSecrets: async () => {
+    if (adaptateurEnvironnement.maintenance().actif()) {
+      // eslint-disable-next-line no-console
+      console.log('🏗 Pas de vérification des sels en mode maintenance');
+      return;
+    }
+    const empreintesDesSecretsAppliques = await entrepotSecretHachage.tous();
+    const tousLesSecretsDeHachageDeLaConfig = adaptateurEnvironnement
+      .hachage()
+      .tousLesSecretsDeHachage();
+
+    if (tousLesSecretsDeHachageDeLaConfig.length === 0) {
+      throw new Error('💥 Aucun secret de hachage dans la config.');
+    }
+
+    await verifieQueChaqueSecretEstCoherent(
+      tousLesSecretsDeHachageDeLaConfig,
+      empreintesDesSecretsAppliques,
+      adaptateurHachage
+    );
+  },
+});

--- a/back/src/serveur.ts
+++ b/back/src/serveur.ts
@@ -11,6 +11,7 @@ import { recupereCheminVersFichiersStatiquesParDefaut } from './infra/recupereCh
 import { fabriqueAdaptateurChiffrement } from './infra/adaptateurChiffrement';
 import { EntrepotSecretHachagePostgres } from './infra/entrepotSecretHachagePostgres';
 import { fabriqueServiceVerificationCoherenceSecretsHachage } from './infra/serviceVerificationCoherenceSecretsHachage';
+import { fabriqueMiddleware } from './api/middleware';
 
 const entrepotSecretHachage = new EntrepotSecretHachagePostgres();
 
@@ -51,6 +52,7 @@ serviceCoherenceSecretsHachage
       }),
       recupereCheminsVersFichiersStatiques:
         recupereCheminVersFichiersStatiquesParDefaut,
+      middleware: fabriqueMiddleware({ adaptateurEnvironnement }),
     });
 
     const port = process.env.PORT || 3005;

--- a/back/tests/api/fauxObjets.ts
+++ b/back/tests/api/fauxObjets.ts
@@ -58,6 +58,10 @@ export const fauxAdaptateurEnvironnement: AdaptateurEnvironnement = {
   chiffrement: () => ({
     cleChaCha20Hex: () => 'uneCléCha20Hex',
   }),
+  maintenance: () => ({
+    actif: () => false,
+    detailsPreparation: () => undefined,
+  }),
 };
 
 export type ConfigurationServeurDeTest = ConfigurationServeur & {

--- a/back/tests/api/fauxObjets.ts
+++ b/back/tests/api/fauxObjets.ts
@@ -6,6 +6,7 @@ import { AdaptateurEnvironnement } from '../../src/infra/adaptateurEnvironnement
 import { AdaptateurHachage } from '../../src/infra/adaptateurHachage';
 import { EntrepotRessourcesCyberMemoire } from '../infra/entrepotRessourceCyberMemoire';
 import { EntrepotUtilisateurMemoire } from '../infra/entrepotUtilisateurMemoire';
+import { fabriqueMiddleware } from '../../src/api/middleware';
 
 export const fauxAdaptateurOIDC: AdaptateurOIDC = {
   recupereInformationsUtilisateur: async (_accessToken: string) => ({
@@ -68,6 +69,10 @@ export type ConfigurationServeurDeTest = ConfigurationServeur & {
   entrepotRessourcesCyber: EntrepotRessourcesCyberMemoire;
 };
 
+const middleware = fabriqueMiddleware({
+  adaptateurEnvironnement: fauxAdaptateurEnvironnement,
+});
+
 export const configurationDeTestDuServeur = (): ConfigurationServeurDeTest => ({
   serveurLab: {
     reseau: {
@@ -82,4 +87,5 @@ export const configurationDeTestDuServeur = (): ConfigurationServeurDeTest => ({
   adaptateurJWT: fauxAdaptateurJWT,
   entrepotUtilisateur: new EntrepotUtilisateurMemoire(),
   recupereCheminsVersFichiersStatiques: () => [join(__dirname, '../pagesDeTest')],
+  middleware
 });

--- a/back/tests/api/middleware.spec.ts
+++ b/back/tests/api/middleware.spec.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { Request, Response } from 'express';
+import { fabriqueMiddleware, Middleware } from '../../src/api/middleware';
+import { createRequest, createResponse, MockResponse } from 'node-mocks-http';
+import { fauxAdaptateurEnvironnement } from './fauxObjets';
+import { Utilisateur } from '../../src/metier/utilisateur';
+import { AdaptateurEnvironnement } from '../../src/infra/adaptateurEnvironnement';
+
+describe('Le middleware', () => {
+  let requete: Request & {
+    emailUtilisateurCourant?: string;
+    utilisateur?: Utilisateur | undefined;
+  };
+  let reponse: MockResponse<Response>;
+  let middleware: Middleware;
+  let adaptateurEnvironnement: AdaptateurEnvironnement;
+  let vueRendue: string;
+
+  beforeEach(() => {
+    requete = createRequest();
+    reponse = createResponse();
+    reponse.render = (vue) => (vueRendue = vue);
+    adaptateurEnvironnement = { ...fauxAdaptateurEnvironnement };
+    middleware = fabriqueMiddleware({
+      adaptateurEnvironnement,
+    });
+  });
+
+  describe('sur vérification du mode maintenance', () => {
+    it('affiche la page de maintenance lorsque le mode est actif', async () => {
+      adaptateurEnvironnement.maintenance = () => ({
+        actif: () => true,
+        detailsPreparation: () => undefined,
+      });
+
+      await middleware.verifieModeMaintenance(requete, reponse, () => {});
+
+      expect(reponse.statusCode).toBe(503);
+      expect(vueRendue).toBe('maintenance');
+    });
+
+    it('appelle la suite lorsque le mode est inactif', async () => {
+      adaptateurEnvironnement.maintenance = () => ({
+        actif: () => false,
+        detailsPreparation: () => undefined,
+      });
+      let suiteAppelee = false;
+
+      await middleware.verifieModeMaintenance(requete, reponse, () => {
+        suiteAppelee = true;
+      });
+
+      expect(suiteAppelee).toBeTruthy();
+    });
+  });
+});

--- a/back/tests/infra/serviceVerificationCoherenceSecretsHachage.spec.ts
+++ b/back/tests/infra/serviceVerificationCoherenceSecretsHachage.spec.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it } from 'vitest';
+import {
+  fauxAdaptateurEnvironnement,
+  fauxAdaptateurHachage,
+} from '../api/fauxObjets';
+import { fabriqueServiceVerificationCoherenceSecretsHachage } from '../../src/infra/serviceVerificationCoherenceSecretsHachage';
+import { EntrepotSecretHachage } from '../../src/infra/entrepotSecretHachagePostgres';
+import { AdaptateurHachage } from '../../src/infra/adaptateurHachage';
+
+describe('Le service de vérification de la cohérence des secrets de hachage', () => {
+  it('jette une erreur si un secret est invalide', async () => {
+    const adaptateurEnvironnement = {
+      ...fauxAdaptateurEnvironnement,
+      hachage: () => ({
+        tousLesSecretsDeHachage: () => [
+          { version: 1, secret: 'unAutreSecret' },
+        ],
+      }),
+    };
+    const entrepotSecretHachage: EntrepotSecretHachage = {
+      tous: async () => [{ version: 1, empreinte: 'secret-crypte' }],
+    };
+    const adaptateurHachage: AdaptateurHachage = {
+      ...fauxAdaptateurHachage,
+      compareBCrypt: async () => false,
+    };
+
+    const service = fabriqueServiceVerificationCoherenceSecretsHachage({
+      adaptateurHachage,
+      entrepotSecretHachage,
+      adaptateurEnvironnement,
+    });
+
+    await expect(() => service.verifieCoherenceSecrets()).rejects.toThrow(
+      '💥 La version 1 du secret de la config a une valeur différente de celle déjà appliquée.'
+    );
+  });
+
+  it("jette une erreur si le deuxième secret est invalide, peu importe l'ordre", async () => {
+    const adaptateurEnvironnement = {
+      ...fauxAdaptateurEnvironnement,
+      hachage: () => ({
+        tousLesSecretsDeHachage: () => [
+          { version: 2, secret: 'unAutresecret' },
+          { version: 1, secret: 'secret' },
+        ],
+      }),
+    };
+    const entrepotSecretHachage: EntrepotSecretHachage = {
+      tous: async () => [
+        { version: 1, empreinte: 'secret-crypte' },
+        { version: 2, empreinte: 'secret2-crypte' },
+      ],
+    };
+    const adaptateurHachage: AdaptateurHachage = {
+      ...fauxAdaptateurHachage,
+      compareBCrypt: async (secretEnClair) => secretEnClair !== 'unAutresecret',
+    };
+
+    const service = fabriqueServiceVerificationCoherenceSecretsHachage({
+      adaptateurHachage,
+      entrepotSecretHachage,
+      adaptateurEnvironnement,
+    });
+
+    await expect(() => service.verifieCoherenceSecrets()).rejects.toThrow(
+      '💥 La version 2 du secret de la config a une valeur différente de celle déjà appliquée.'
+    );
+  });
+
+  it('ne fait rien si tous les secrets sont valides', async () => {
+    const adaptateurEnvironnement = {
+      ...fauxAdaptateurEnvironnement,
+      hachage: () => ({
+        tousLesSecretsDeHachage: () => [
+          { version: 1, secret: 'secret' },
+          { version: 2, secret: 'secret2' },
+        ],
+      }),
+    };
+    const entrepotSecretHachage: EntrepotSecretHachage = {
+      tous: async () => [
+        { version: 1, empreinte: 'secret-crypte' },
+        { version: 2, empreinte: 'secret2-crypte' },
+      ],
+    };
+    const adaptateurHachage: AdaptateurHachage = {
+      ...fauxAdaptateurHachage,
+      compareBCrypt: async () => true,
+    };
+
+    const service = fabriqueServiceVerificationCoherenceSecretsHachage({
+      adaptateurHachage,
+      entrepotSecretHachage,
+      adaptateurEnvironnement,
+    });
+
+    await expect(service.verifieCoherenceSecrets()).resolves.toBeUndefined();
+  });
+
+  it("jette une erreur si un secret n'est pas présent dans la persistance", async () => {
+    const adaptateurEnvironnement = {
+      ...fauxAdaptateurEnvironnement,
+      hachage: () => ({
+        tousLesSecretsDeHachage: () => [
+          { version: 1, secret: 'secret' },
+          { version: 2, secret: 'secret2' },
+        ],
+      }),
+    };
+    const entrepotSecretHachage: EntrepotSecretHachage = {
+      tous: async () => [{ version: 2, empreinte: 'secret2-crypte' }],
+    };
+    const adaptateurHachage: AdaptateurHachage = {
+      ...fauxAdaptateurHachage,
+      compareBCrypt: async () => true,
+    };
+
+    const service = fabriqueServiceVerificationCoherenceSecretsHachage({
+      adaptateurHachage,
+      entrepotSecretHachage,
+      adaptateurEnvironnement,
+    });
+
+    await expect(() => service.verifieCoherenceSecrets()).rejects.toThrow(
+      '💥 La version 1 du secret noté dans la config est manquante dans la persistance.'
+    );
+  });
+
+  it("jette une erreur si un secret de la persistance n'est pas présent dans la config", async () => {
+    const adaptateurEnvironnement = {
+      ...fauxAdaptateurEnvironnement,
+      hachage: () => ({
+        tousLesSecretsDeHachage: () => [{ version: 2, secret: 'secret2' }],
+      }),
+    };
+    const entrepotSecretHachage: EntrepotSecretHachage = {
+      tous: async () => [
+        { version: 2, empreinte: 'secret2-crypte' },
+        { version: 1, empreinte: 'secret-crypte' },
+      ],
+    };
+    const adaptateurHachage: AdaptateurHachage = {
+      ...fauxAdaptateurHachage,
+      compareBCrypt: async () => true,
+    };
+
+    const service = fabriqueServiceVerificationCoherenceSecretsHachage({
+      adaptateurHachage,
+      entrepotSecretHachage,
+      adaptateurEnvironnement,
+    });
+
+    await expect(() => service.verifieCoherenceSecrets()).rejects.toThrow(
+      '💥 La version 1 du secret déjà appliquée est manquante dans la config.'
+    );
+  });
+
+  it("jette une erreur si aucun secret n'est présent dans la config", async () => {
+    const adaptateurEnvironnement = {
+      ...fauxAdaptateurEnvironnement,
+      hachage: () => ({
+        tousLesSecretsDeHachage: () => [],
+      }),
+    };
+
+    const entrepotSecretHachage: EntrepotSecretHachage = {
+      tous: async () => [{ version: 1, empreinte: 'secret-crypte' }],
+    };
+
+    const service = fabriqueServiceVerificationCoherenceSecretsHachage({
+      adaptateurHachage: fauxAdaptateurHachage,
+      entrepotSecretHachage,
+      adaptateurEnvironnement,
+    });
+
+    await expect(() => service.verifieCoherenceSecrets()).rejects.toThrow(
+      '💥 Aucun secret de hachage dans la config.'
+    );
+  });
+});

--- a/back/tests/infra/serviceVerificationCoherenceSecretsHachage.spec.ts
+++ b/back/tests/infra/serviceVerificationCoherenceSecretsHachage.spec.ts
@@ -165,7 +165,7 @@ describe('Le service de vérification de la cohérence des secrets de hachage', 
     };
 
     const entrepotSecretHachage: EntrepotSecretHachage = {
-      tous: async () => [{ version: 1, empreinte: 'secret-crypte' }],
+      tous: async () => [],
     };
 
     const service = fabriqueServiceVerificationCoherenceSecretsHachage({

--- a/back/vues/maintenance.pug
+++ b/back/vues/maintenance.pug
@@ -1,0 +1,12 @@
+doctype html
+html(lang='fr')
+    head
+        meta(charset='UTF-8')
+        meta(name='viewport' content='width=device-width, initial-scale=1')
+        title DemainSpécialisteCyber
+        script(type='module' defer src='/assets/dsc.js')
+        link(rel="stylesheet" type="text/css" href="/assets/style.css")
+
+    body
+        p Le site est en maintenance
+        include ./pied-de-page

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,6 +52,7 @@
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-prettier": "^5.5.4",
         "jiti": "^2.5.1",
+        "node-mocks-http": "^1.17.2",
         "supertest": "^7.1.4",
         "ts-node": "^10.9.2",
         "tsx": "^4.20.5",
@@ -5652,6 +5653,50 @@
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
         "node-gyp-build-test": "build-test.js"
+      }
+    },
+    "node_modules/node-mocks-http": {
+      "version": "1.17.2",
+      "resolved": "https://registry.npmjs.org/node-mocks-http/-/node-mocks-http-1.17.2.tgz",
+      "integrity": "sha512-HVxSnjNzE9NzoWMx9T9z4MLqwMpLwVvA0oVZ+L+gXskYXEJ6tFn3Kx4LargoB6ie7ZlCLplv7QbWO6N+MysWGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^1.3.7",
+        "content-disposition": "^0.5.3",
+        "depd": "^1.1.0",
+        "fresh": "^0.5.2",
+        "merge-descriptors": "^1.0.1",
+        "methods": "^1.1.2",
+        "mime": "^1.3.4",
+        "parseurl": "^1.3.3",
+        "range-parser": "^1.2.0",
+        "type-is": "^1.6.18"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@types/express": "^4.17.21 || ^5.0.0",
+        "@types/node": "*"
+      },
+      "peerDependenciesMeta": {
+        "@types/express": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-mocks-http/node_modules/depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/normalize-package-data": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
     "migre-bdd": "npm run migre-bdd --workspace=back",
     "start": "npm start --workspace=back",
     "test": "npm run test --workspaces --if-present",
-    "typecheck": "npm run typecheck --workspaces --if-present"
+    "typecheck": "npm run typecheck --workspaces --if-present",
+    "admin": "node -e \"const admin = new (require('./back/dist/src/admin/consoleAdministration.js').ConsoleAdministration)()\" -i",
+    "admin:dev": "npm run build -w back && node --env-file back/.env -e \"const admin = new (require('./back/dist/src/admin/consoleAdministration.js').ConsoleAdministration)()\" -i"
   },
   "devDependencies": {
     "@eslint/js": "^9.34.0",


### PR DESCRIPTION
Au démarrage du serveur, on vérifie que les secrets de hachage sont cohérents, c’est-à-dire que la configuration des secrets de hachage correspond à l’empreinte qui en a été faite et stockée dans la table `secrets_hachage`. Cela permet d’éviter une modification accidentelle des secrets de hachage dans les variables d’environnement. 
On ajoute, pour créer ces empreintes, une console d’administration. 