### PR TITLE
Ajoute la page liste des jeux à l’état vide

### DIFF
--- a/back/src/api/ressourcesPages.ts
+++ b/back/src/api/ressourcesPages.ts
@@ -6,6 +6,7 @@ const pages = [
   { route: '/catalogue', protegee: false },
   { route: '/maintenance', protegee: false },
   { route: '/nouveau-jeu', protegee: true },
+  { route: '/mes-jeux', protegee: true },
 ];
 
 export const ressourcesPages = (configurationServeur: ConfigurationServeur) => {

--- a/back/tests/api/dsc.spec.ts
+++ b/back/tests/api/dsc.spec.ts
@@ -1,11 +1,7 @@
-import { Express } from 'express';
 import request from 'supertest';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { AdaptateurJWT } from '../../src/api/adaptateurJWT';
+import { describe, expect, it } from 'vitest';
 import { creeServeur } from '../../src/api/dsc';
-import { MoteurDeRendu } from '../../src/api/moteurDeRendu';
-import { encodeSession } from './cookie';
-import { configurationDeTestDuServeur, fauxAdaptateurJWT } from './fauxObjets';
+import { configurationDeTestDuServeur } from './fauxObjets';
 
 describe("L'API DSC", () => {
   describe('concernant la limitation de trafic', () => {
@@ -39,52 +35,6 @@ describe("L'API DSC", () => {
       const reponse = await requete.get('/');
 
       expect(reponse.status).toEqual(200);
-    });
-  });
-
-  describe('concernant les pages protégées', () => {
-    let serveur: Express;
-
-    const moteurDeRendu: MoteurDeRendu = {
-      rends: vi.fn().mockImplementation((reponse) => reponse.sendStatus(200)),
-    };
-    beforeEach(() => {
-      const adaptateurJWT: AdaptateurJWT = {
-        ...fauxAdaptateurJWT,
-        decode: (jeton?: string) => {
-          if (!jeton) {
-            throw new Error();
-          }
-          return {};
-        },
-      };
-      serveur = creeServeur({
-        ...configurationDeTestDuServeur(),
-        adaptateurJWT,
-        moteurDeRendu,
-      });
-    });
-    it("redirige vers la connexion lorsqu'on est pas connecté", async () => {
-      const reponse = await request(serveur).get('/nouveau-jeu');
-
-      expect(reponse.status).toEqual(302);
-      expect(reponse.headers.location).toEqual('/connexion');
-    });
-
-    it('rends la page quand on est connecté', async () => {
-      const cookie = encodeSession({
-        token: 'jeton de test',
-      });
-
-      const reponse = await request(serveur)
-        .get('/nouveau-jeu')
-        .set('Cookie', [cookie]);
-
-      expect(reponse.status).toEqual(200);
-      expect(moteurDeRendu.rends).toHaveBeenCalledExactlyOnceWith(
-        expect.any(Object),
-        'nouveau-jeu',
-      );
     });
   });
 });

--- a/back/tests/api/fauxObjets.ts
+++ b/back/tests/api/fauxObjets.ts
@@ -81,7 +81,7 @@ export type ConfigurationServeurDeTest = ConfigurationServeur & {
 };
 
 const fauxMoteurDeRendu: MoteurDeRendu = {
-  rends: (reponse, _vue, _options) => reponse.sendStatus(200),
+  rends: (reponse, _vue, _options) => reponse.sendStatus(reponse.statusCode || 200),
 };
 
 export const fauxAdaptateurRechercheEntreprise: AdaptateurRechercheEntreprise =

--- a/back/tests/api/ressourcesPages.spec.ts
+++ b/back/tests/api/ressourcesPages.spec.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import request from 'supertest';
+import { creeServeur } from '../../src/api/dsc';
+import { configurationDeTestDuServeur } from './fauxObjets';
+import { encodeSession } from './cookie';
+
+describe('Les ressources de page', () => {
+  it("renvoie une page pour les jeux d'un enseignant", async () => {
+    const serveur = creeServeur(configurationDeTestDuServeur());
+    const cookie = encodeSession({
+      token: 'jeton de test',
+    });
+
+    const reponse = await request(serveur)
+      .get('/mes-jeux')
+      .set('Cookie', [cookie]);
+
+    expect(reponse.status).toBe(200);
+  });
+
+  it('protège la page des jeux', async () => {
+    const serveur = creeServeur(configurationDeTestDuServeur());
+
+    const reponse = await request(serveur).get('/mes-jeux');
+
+    expect(reponse.status).toBe(302);
+    expect(reponse.headers.location).toBe('/connexion');
+  });
+});

--- a/back/tests/api/ressourcesPages.spec.ts
+++ b/back/tests/api/ressourcesPages.spec.ts
@@ -5,25 +5,30 @@ import { configurationDeTestDuServeur } from './fauxObjets';
 import { encodeSession } from './cookie';
 
 describe('Les ressources de page', () => {
-  it("renvoie une page pour les jeux d'un enseignant", async () => {
-    const serveur = creeServeur(configurationDeTestDuServeur());
-    const cookie = encodeSession({
-      token: 'jeton de test',
-    });
+  describe.each(['nouveau-jeu', 'mes-jeux'])(
+    `concernant la page protégée /%s`,
+    (nomPage) => {
+      it('renvoie la page pour un utilisateur connecté', async () => {
+        const serveur = creeServeur(configurationDeTestDuServeur());
+        const cookie = encodeSession({
+          token: 'jeton de test',
+        });
 
-    const reponse = await request(serveur)
-      .get('/mes-jeux')
-      .set('Cookie', [cookie]);
+        const reponse = await request(serveur)
+          .get(`/${nomPage}`)
+          .set('Cookie', [cookie]);
 
-    expect(reponse.status).toBe(200);
-  });
+        expect(reponse.status).toBe(200);
+      });
 
-  it('protège la page des jeux', async () => {
-    const serveur = creeServeur(configurationDeTestDuServeur());
+      it("redirige s'il n'y a pas d'utilisateur connecté", async () => {
+        const serveur = creeServeur(configurationDeTestDuServeur());
 
-    const reponse = await request(serveur).get('/mes-jeux');
+        const reponse = await request(serveur).get(`/${nomPage}`);
 
-    expect(reponse.status).toBe(302);
-    expect(reponse.headers.location).toBe('/connexion');
-  });
+        expect(reponse.status).toBe(302);
+        expect(reponse.headers.location).toBe('/connexion');
+      });
+    },
+  );
 });

--- a/back/vues/mes-jeux.pug
+++ b/back/vues/mes-jeux.pug
@@ -1,0 +1,7 @@
+extends base
+block variables
+  - var titrePage = "Mes jeux"
+  - var descriptionPage = ""
+
+block contenu
+    p Liste de mes jeux

--- a/back/vues/mes-jeux.pug
+++ b/back/vues/mes-jeux.pug
@@ -4,4 +4,4 @@ block variables
   - var descriptionPage = ""
 
 block contenu
-    p Liste de mes jeux
+    dsc-mes-jeux

--- a/front/src/index.ts
+++ b/front/src/index.ts
@@ -3,3 +3,4 @@ export * from './Catalogue.svelte';
 export * from './ZoneIdentification.svelte';
 export * from './CreationCompte.svelte';
 export * from './NouveauJeu.svelte';
+export * from './jeux/MesJeux.svelte';

--- a/front/src/jeux/MesJeux.svelte
+++ b/front/src/jeux/MesJeux.svelte
@@ -1,0 +1,42 @@
+<svelte:options customElement={{ tag: 'dsc-mes-jeux', shadow: 'none' }} />
+
+<script lang="ts">
+  const deposeUnJeu = () => {
+    window.location.assign('/nouveau-jeu');
+  };
+</script>
+
+<dsfr-container>
+  <div class="container">
+    <h4>Valorisez la créativité de vos élèves</h4>
+    <p>
+      Partagez les jeux élaborés par vos élèves lors de séquence CyberEnJeux.
+    </p>
+    <dsfr-button
+      label="Déposer un jeu"
+      onclick={deposeUnJeu}
+      role="button"
+      onkeydown={deposeUnJeu}
+      tabindex={0}
+    ></dsfr-button>
+  </div>
+  <div>
+    <span>
+      Rejoignez la communauté CyberEnJeux pour poser vos questions ou partager
+      votre expérience. Rejoindre la communauté
+    </span>
+  </div>
+</dsfr-container>
+
+<style>
+  .container {
+    align-items: center;
+    align-self: stretch;
+    background: #f5f5fe;
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+    justify-content: center;
+    padding: 2rem;
+  }
+</style>


### PR DESCRIPTION
Permet d’afficher la page avec l’encart d’ajout d’un jeu lorsque l’enseignant n’a toujours pas créé de jeux.

<img width="1213" height="536" alt="Capture d’écran 2025-09-16 à 18 08 23" src="https://github.com/user-attachments/assets/99808be8-d27f-4155-921e-39b301182a7b" />
