### PR TITLE
Rends les CSP plus stricts

### DIFF
--- a/back/src/api/middleware.ts
+++ b/back/src/api/middleware.ts
@@ -152,7 +152,7 @@ export const fabriqueMiddleware = ({
           connectSrc: [
             "'self'",
             'https://stats.beta.gouv.fr',
-            'https://data.education.gouv.fr',
+            'https://data.education.gouv.fr/api/v2/catalog/datasets/fr-en-annuaire-education/',
           ],
           mediaSrc: [
             "'self'",


### PR DESCRIPTION
...afin de ne permettre d'accéder qu'à l'annuaire de l'éducation nationale, et pas à tout le domaine