### PR TITLE
[CEJ] Ajoute l'entête de page du mini-site CyberEnJeux

### DIFF
--- a/back/vues/cyber-en-jeux.pug
+++ b/back/vues/cyber-en-jeux.pug
@@ -5,6 +5,35 @@ block variables
   - var descriptionPage = "L'outil pédagogique innovant pour former vos élèves aux enjeux de la cybersécurité par la création de jeux."
   - var classePage = "page-cyber-en-jeux"
 
+block hero
+  div(class="hero")
+    dsfr-container
+      div(class="conteneur")
+        dsfr-breadcrumb(segments=[
+          { id: 'accueil', label: 'Accueil', href: '/' },
+          { id: 'cyber-en-jeux', label: 'CyberEnJeux', href: '#' }
+        ])
+        hgroup
+          h1 CyberEnJeux
+          p L'outil pédagogique innovant pour former vos élèves aux enjeux de la cybersécurité par la création de jeux.
+        div(class="actions")
+          dsfr-button(
+            label="Accèder aux ressources"
+            kind="primary"
+            markup="a"
+            href="/cyber-en-jeux#ressources"
+            target="_self"
+          )
+          dsfr-button(
+            label="Déclarer une action CyberEnJeux"
+            kind="secondary"
+            markup="a"
+            href="/cyber-en-jeux#ressources"
+            target="_blank"
+          )
+        picture(class="illustration")
+          img(src='/assets/images/boites-de-jeux.png' alt='')
+
 block contenu
   dsc-cyber-en-jeux
 

--- a/front/src/_page-cyber-en-jeux.scss
+++ b/front/src/_page-cyber-en-jeux.scss
@@ -1,0 +1,101 @@
+@use 'points-de-rupture' as *;
+
+.page-cyber-en-jeux {
+  .entete {
+    .hero {
+      background: var(--background-alt-blue-cumulus);
+      box-shadow: inset 0 4px 4px 0 rgba(0, 0, 18, 0.06);
+      color: var(--text-default-grey);
+      padding: 0;
+
+      .conteneur {
+        padding: 0 0 1.5rem;
+
+        display: flex;
+        flex-direction: column;
+        gap: 1.5rem;
+
+        hgroup {
+          h1 {
+            color: var(--text-title-blue-france);
+            margin: 0 0 0.5rem;
+          }
+
+          p {
+            font-size: 1.25rem;
+            line-height: 2rem;
+            margin: 0;
+          }
+        }
+
+        .actions {
+          display: flex;
+          flex-direction: column;
+          gap: 1rem;
+        }
+
+        .illustration {
+          background: url('/assets/images/blob.svg') no-repeat center;
+          background-size: calc(100% - 100px) 100%; // Ce calcul affiche l'image de fond correctement suivant la maquette
+          display: block;
+          max-width: 100%;
+          padding: 0 30px;
+          overflow: hidden;
+          position: relative;
+
+          img {
+            display: block;
+            padding: 1.6rem 1.7rem;
+            width: 100%;
+          }
+        }
+
+        @include a-partir-de(sm) {
+          .actions {
+            flex-flow: row nowrap;
+          }
+        }
+
+        @include a-partir-de(md) {
+          display: grid;
+          gap: 0 1.5rem;
+          grid-template-columns: 1fr 1fr;
+          grid-template-rows: auto auto auto;
+
+          hgroup {
+            grid-column: 1;
+            grid-row: 2;
+            margin-bottom: 1.5rem;
+          }
+
+          .actions {
+            flex-direction: column;
+            grid-row: 3;
+            grid-column: 1;
+
+            align-items: flex-start;
+          }
+
+          .illustration {
+            align-self: center;
+            grid-column: 2;
+            grid-row: 2 / span 2;
+
+            img {
+              margin: 0 auto;
+              max-height: 330px;
+              width: auto;
+              max-width: 100%;
+            }
+          }
+        }
+
+        @include a-partir-de(xl) {
+          .actions {
+            flex-flow: row nowrap;
+          }
+        }
+      }
+    }
+  }
+}

--- a/front/src/_standard.scss
+++ b/front/src/_standard.scss
@@ -25,6 +25,21 @@ a {
   text-decoration: none;
 }
 
+h1 {
+  color: var(--text-title-grey);
+  font-size: 2.5rem;
+  line-height: 3rem;
+
+  .fonce & {
+    color: var(--white);
+  }
+
+  @include a-partir-de(sm) {
+    font-size: 3rem;
+    line-height: 3.5rem;
+  }
+}
+
 h2 {
   color: var(--grey-50-1000);
   font-style: normal;

--- a/front/src/index.scss
+++ b/front/src/index.scss
@@ -13,3 +13,4 @@
 @use 'encart-intro';
 
 @use 'page-catalogue';
+@use 'page-cyber-en-jeux';


### PR DESCRIPTION
<img width="1850" height="651" alt="image" src="https://github.com/user-attachments/assets/764e783a-0c35-462c-8e9b-8b651e67c539" />

<img width="992" height="586" alt="image" src="https://github.com/user-attachments/assets/c95f1397-02e8-4fae-bcff-b82a0b798e80" />

<img width="768" height="599" alt="image" src="https://github.com/user-attachments/assets/2a9afa06-a15b-4cb8-bb13-fc9022e370ff" />

<img width="320" height="874" alt="image" src="https://github.com/user-attachments/assets/575f9f3c-fa5f-43ad-899d-3a6c806db148" />
